### PR TITLE
Fix handshake for echo test

### DIFF
--- a/TESTS/mbed_drivers/echo/main.cpp
+++ b/TESTS/mbed_drivers/echo/main.cpp
@@ -26,15 +26,24 @@ using namespace utest::v1;
 // Echo server (echo payload to host)
 template<int N>
 void test_case_echo_server_x() {
-    char _key[10] = {};
+    char _key[12] = {};
     char _value[128] = {};
     const int echo_count = N;
+    const char _key_const[] = "echo_count";
+    int expected_key = 1;
 
     // Handshake with host
-    greentea_send_kv("echo_count", echo_count);
-    greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+    do {
+        greentea_send_kv(_key_const, echo_count);
+        greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+        expected_key = strcmp(_key_const, _key);
+        printf("TX string %s and %d \r\n",_key,expected_key);
+    } while (expected_key);
+
     TEST_ASSERT_EQUAL_INT(echo_count, atoi(_value));
 
+    printf("getting first packet from host ......\r\n");
+    greentea_send_kv("get_uuid",1);
     for (int i=0; i < echo_count; ++i) {
         greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
         greentea_send_kv(_key, _value);


### PR DESCRIPTION
In case where multiple sync packet are send from host If first sync packet is missed by device and its still in buffer. when sync packet is received by device, it will ask for echo_count.
As we have more then one sync packet the subsequent sync packet will be considered as echo_count, and will be parsed wrong.