### PR TITLE
reduce the load on uart traffic

### DIFF
--- a/TESTS/mbed_drivers/echo/main.cpp
+++ b/TESTS/mbed_drivers/echo/main.cpp
@@ -26,7 +26,7 @@ using namespace utest::v1;
 // Echo server (echo payload to host)
 template<int N>
 void test_case_echo_server_x() {
-    char _key[10] = {};
+    char _key[11] = {};
     char _value[128] = {};
     const int echo_count = N;
     const char _key_const[] = "echo_count";

--- a/TESTS/mbed_drivers/echo/main.cpp
+++ b/TESTS/mbed_drivers/echo/main.cpp
@@ -26,7 +26,7 @@ using namespace utest::v1;
 // Echo server (echo payload to host)
 template<int N>
 void test_case_echo_server_x() {
-    char _key[12] = {};
+    char _key[10] = {};
     char _value[128] = {};
     const int echo_count = N;
     const char _key_const[] = "echo_count";
@@ -37,13 +37,9 @@ void test_case_echo_server_x() {
         greentea_send_kv(_key_const, echo_count);
         greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
         expected_key = strcmp(_key_const, _key);
-        printf("TX string %s and %d \r\n",_key,expected_key);
     } while (expected_key);
 
     TEST_ASSERT_EQUAL_INT(echo_count, atoi(_value));
-
-    printf("getting first packet from host ......\r\n");
-    greentea_send_kv("get_uuid",1);
     for (int i=0; i < echo_count; ++i) {
         greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
         greentea_send_kv(_key, _value);

--- a/TESTS/mbed_drivers/echo/main.cpp
+++ b/TESTS/mbed_drivers/echo/main.cpp
@@ -56,13 +56,11 @@ utest::v1::status_t greentea_failure_handler(const Case *const source, const fai
 }
 
 Case cases[] = {
-    Case("Echo server: x16", test_case_echo_server_x<16>, greentea_failure_handler),
-    Case("Echo server: x32", test_case_echo_server_x<32>, greentea_failure_handler),
-    Case("Echo server: x64", test_case_echo_server_x<64>, greentea_failure_handler),
+    Case("Echo server: x16", test_case_echo_server_x<16>, greentea_failure_handler)
 };
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases) {
-    GREENTEA_SETUP(180, "echo");
+    GREENTEA_SETUP(60, "echo");
     return greentea_test_setup_handler(number_of_cases);
 }
 

--- a/TESTS/mbed_drivers/echo/main.cpp
+++ b/TESTS/mbed_drivers/echo/main.cpp
@@ -32,9 +32,9 @@ void test_case_echo_server_x() {
     const char _key_const[] = "echo_count";
     int expected_key = 1;
 
+    greentea_send_kv(_key_const, echo_count);
     // Handshake with host
     do {
-        greentea_send_kv(_key_const, echo_count);
         greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
         expected_key = strcmp(_key_const, _key);
     } while (expected_key);


### PR DESCRIPTION
As we are running tests in parallel on 30 devices,  reduce the traffic on uart now echo test floods the uart buffer.